### PR TITLE
Disable fetching file metadata, requires Restricted scope

### DIFF
--- a/tap_google_sheets/streams.py
+++ b/tap_google_sheets/streams.py
@@ -645,7 +645,7 @@ class SheetsLoaded(GoogleSheets):
 # "spreadsheet_metadata" -> get sheets in the spreadsheet and load sheet's records
 #       and prepare records for "sheet_metadata" and "sheets_loaded" streams
 STREAMS = OrderedDict()
-STREAMS['file_metadata'] = FileMetadata
+#STREAMS['file_metadata'] = FileMetadata
 STREAMS['spreadsheet_metadata'] = SpreadSheetMetadata
 STREAMS['sheet_metadata'] = SheetMetadata
 STREAMS['sheets_loaded'] = SheetsLoaded

--- a/tap_google_sheets/sync.py
+++ b/tap_google_sheets/sync.py
@@ -61,13 +61,13 @@ def sync(client, config, catalog, state):
                 stream_obj.sync(catalog, state, sheets_loaded_records)
 
         # sync file metadata
-        elif stream_name == "file_metadata":
-            file_changed, file_modified_time = stream_obj.sync(catalog, state, selected_streams)
-            if not file_changed:
-                break
+        #elif stream_name == "file_metadata":
+        #    file_changed, file_modified_time = stream_obj.sync(catalog, state, selected_streams)
+        #    if not file_changed:
+        #        break
 
         LOGGER.info("FINISHED Syncing: %s", stream_name)
 
     # write "file_metadata" bookmark, as we have successfully synced all the sheet's records
     # it will force to re-sync of there is any interrupt between the sync
-    write_bookmark(state, 'file_metadata', strftime(file_modified_time))
+    # write_bookmark(state, 'file_metadata', strftime(file_modified_time))


### PR DESCRIPTION
Disable fetching file metadata, this requires a Restricted scope drive.metadata.readonly.

This means selected spreadsheet file will now be synced on each run, even if file did not change.
The lastmodified timestamp of the file was used as bookmark.