### PR TITLE
Bump backoff and requests for Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(name='tap-google-sheets',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_google_sheets'],
       install_requires=[
-          'backoff==1.8.0',
-          'requests==2.22.0',
+          'backoff>=2.2.1',
+          'requests>=2.28.0',
           'singer-python @ git+https://github.com/peliqan-io/singer-python@master'
       ],
       extras_require={

--- a/tests/regression/.gitignore
+++ b/tests/regression/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -1,0 +1,53 @@
+# tap-google-sheets — Python 3.11 Regression Tests
+
+Before/after parity test for the Python 3.9 → 3.11 migration.
+
+## Strategy
+
+1. **Capture** baseline on pre-migration `master` + Python 3.9: discover, select all streams, sync, record schemas / state-key names / record field names.
+2. **Compare** on migration branch + Python 3.11 — assert schemas unchanged, no streams dropped, all baseline fields still present.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `conftest.py` | Shared fixtures: config builder, discover + select_all, sync runner, message parser |
+| `capture.py` | Standalone — run once on Python 3.9 to write `baseline/` |
+| `test_regression.py` | pytest suite — run on Python 3.11 to verify parity |
+| `run_capture.sh` | Wrapper that runs `capture.py` in `python:3.9-slim` Docker |
+| `run_tests.sh` | Wrapper that runs pytest in `python:3.11-slim` Docker |
+| `baseline/` | Committed reference output: schemas, state keys, record fields, catalog, meta |
+
+## Usage
+
+Required env vars:
+
+```bash
+export TAP_GOOGLE_SHEETS_CLIENT_ID=...
+export TAP_GOOGLE_SHEETS_CLIENT_SECRET=...
+export TAP_GOOGLE_SHEETS_REFRESH_TOKEN=...   # OAuth refresh token with spreadsheets.readonly scope
+export TAP_GOOGLE_SHEETS_SPREADSHEET_ID=...  # the long ID from the sheet URL
+export TAP_GOOGLE_SHEETS_START_DATE=2010-01-01T00:00:00Z   # optional
+```
+
+### Capture baseline (pre-migration code on Python 3.9)
+
+```bash
+git worktree add /tmp/tap-google-sheets-master master
+cp -r tests/regression /tmp/tap-google-sheets-master/tests/regression
+cd /tmp/tap-google-sheets-master
+bash tests/regression/run_capture.sh
+cp -r tests/regression/baseline /path/to/migration-branch/tests/regression/
+git worktree remove /tmp/tap-google-sheets-master
+```
+
+### Run tests (migration branch on Python 3.11)
+
+```bash
+bash tests/regression/run_tests.sh
+```
+
+## Notes
+
+- The OAuth client used for tap-google-sheets is **not** the SSO client — it lives in a separate Google Cloud project (`1013877377144`) which has the Sheets API enabled. The SSO project doesn't have Sheets API turned on.
+- `prompt=consent` + `access_type=offline` are required in the authorize URL to mint a refresh_token. Without `prompt=consent`, Google won't re-issue a refresh_token on re-auth.

--- a/tests/regression/baseline/catalog.json
+++ b/tests/regression/baseline/catalog.json
@@ -1,0 +1,886 @@
+{
+  "streams": [
+    {
+      "key_properties": [
+        "spreadsheetId"
+      ],
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "forced-replication-method": "FULL_TABLE",
+            "inclusion": "available",
+            "selected": true,
+            "table-key-properties": [
+              "spreadsheetId"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "spreadsheetId"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "properties"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "spreadsheetUrl"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        }
+      ],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "properties": {
+            "additionalProperties": false,
+            "properties": {
+              "autoRecalc": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "locale": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "timeZone": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "title": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "spreadsheetId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "spreadsheetUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "stream": "spreadsheet_metadata",
+      "tap_stream_id": "spreadsheet_metadata"
+    },
+    {
+      "key_properties": [
+        "__sdc_row"
+      ],
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "forced-replication-method": "FULL_TABLE",
+            "inclusion": "available",
+            "selected": true,
+            "table-key-properties": [
+              "__sdc_row"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_spreadsheet_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_sheet_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_row"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ID"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Department"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Position"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Annual Salary (USD)"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Bonus (USD)"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Stock Options Granted"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Benefits Package"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Start Date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Performance Rating (2024)"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Next Review Date"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        }
+      ],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "Annual Salary (USD)": {
+            "anyOf": [
+              {
+                "format": "singer.decimal",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          },
+          "Benefits Package": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Bonus (USD)": {
+            "anyOf": [
+              {
+                "format": "singer.decimal",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          },
+          "Department": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ID": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Next Review Date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          },
+          "Performance Rating (2024)": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Position": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Start Date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          },
+          "Stock Options Granted": {
+            "anyOf": [
+              {
+                "format": "singer.decimal",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          },
+          "__sdc_row": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "__sdc_sheet_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "__sdc_spreadsheet_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "stream": "salary",
+      "tap_stream_id": "salary"
+    },
+    {
+      "key_properties": [
+        "__sdc_row"
+      ],
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "forced-replication-method": "FULL_TABLE",
+            "inclusion": "available",
+            "selected": true,
+            "table-key-properties": [
+              "__sdc_row"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_spreadsheet_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_sheet_id"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "__sdc_row"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Name"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Designation"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "Home"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "ID"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        }
+      ],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "Designation": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Home": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ID": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "__sdc_row": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "__sdc_sheet_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "__sdc_spreadsheet_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "stream": "empdetails",
+      "tap_stream_id": "empdetails"
+    },
+    {
+      "key_properties": [
+        "sheetId"
+      ],
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "forced-replication-method": "FULL_TABLE",
+            "inclusion": "available",
+            "selected": true,
+            "table-key-properties": [
+              "sheetId"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "spreadsheetId"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sheetId"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "title"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "index"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sheetType"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sheetUrl"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "gridProperties"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "columns"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        }
+      ],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "columns": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "columnIndex": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "columnLetter": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "columnName": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "columnSkipped": {
+                      "type": [
+                        "null",
+                        "boolean"
+                      ]
+                    },
+                    "columnType": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "format": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "type": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gridProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "columnCount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "frozenColumnCount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "frozenRowCount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "rowCount": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            },
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "index": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "sheetId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "sheetType": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "sheetUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "spreadsheetId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "stream": "sheet_metadata",
+      "tap_stream_id": "sheet_metadata"
+    },
+    {
+      "key_properties": [
+        "spreadsheetId",
+        "sheetId",
+        "loadDate"
+      ],
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "forced-replication-method": "FULL_TABLE",
+            "inclusion": "available",
+            "selected": true,
+            "table-key-properties": [
+              "spreadsheetId",
+              "sheetId",
+              "loadDate"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "spreadsheetId"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "sheetId"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "title"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "loadDate"
+          ],
+          "metadata": {
+            "inclusion": "automatic",
+            "selected": true
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "lastRowNumber"
+          ],
+          "metadata": {
+            "inclusion": "available",
+            "selected": true
+          }
+        }
+      ],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+          "lastRowNumber": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "loadDate": {
+            "format": "date-time",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "sheetId": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "spreadsheetId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "stream": "sheets_loaded",
+      "tap_stream_id": "sheets_loaded"
+    }
+  ]
+}

--- a/tests/regression/baseline/meta.json
+++ b/tests/regression/baseline/meta.json
@@ -1,0 +1,10 @@
+{
+  "python_version": "3.9.25",
+  "streams": [
+    "spreadsheet_metadata",
+    "salary",
+    "empdetails",
+    "sheet_metadata",
+    "sheets_loaded"
+  ]
+}

--- a/tests/regression/baseline/record_fields.json
+++ b/tests/regression/baseline/record_fields.json
@@ -1,0 +1,48 @@
+{
+  "empdetails": [
+    "Designation",
+    "Home",
+    "ID",
+    "Name",
+    "__sdc_row",
+    "__sdc_sheet_id",
+    "__sdc_spreadsheet_id"
+  ],
+  "salary": [
+    "Annual Salary (USD)",
+    "Benefits Package",
+    "Bonus (USD)",
+    "Department",
+    "ID",
+    "Next Review Date",
+    "Performance Rating (2024)",
+    "Position",
+    "Start Date",
+    "Stock Options Granted",
+    "__sdc_row",
+    "__sdc_sheet_id",
+    "__sdc_spreadsheet_id"
+  ],
+  "sheet_metadata": [
+    "columns",
+    "gridProperties",
+    "index",
+    "sheetId",
+    "sheetType",
+    "sheetUrl",
+    "spreadsheetId",
+    "title"
+  ],
+  "sheets_loaded": [
+    "lastRowNumber",
+    "loadDate",
+    "sheetId",
+    "spreadsheetId",
+    "title"
+  ],
+  "spreadsheet_metadata": [
+    "properties",
+    "spreadsheetId",
+    "spreadsheetUrl"
+  ]
+}

--- a/tests/regression/baseline/schemas.json
+++ b/tests/regression/baseline/schemas.json
@@ -1,0 +1,420 @@
+{
+  "empdetails": {
+    "additionalProperties": false,
+    "properties": {
+      "Designation": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Home": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "ID": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "__sdc_row": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "__sdc_sheet_id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "__sdc_spreadsheet_id": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "salary": {
+    "additionalProperties": false,
+    "properties": {
+      "Annual Salary (USD)": {
+        "anyOf": [
+          {
+            "format": "singer.decimal",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "Benefits Package": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Bonus (USD)": {
+        "anyOf": [
+          {
+            "format": "singer.decimal",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "Department": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "ID": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Next Review Date": {
+        "anyOf": [
+          {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "Performance Rating (2024)": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Position": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "Start Date": {
+        "anyOf": [
+          {
+            "format": "date",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "Stock Options Granted": {
+        "anyOf": [
+          {
+            "format": "singer.decimal",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "__sdc_row": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "__sdc_sheet_id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "__sdc_spreadsheet_id": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "sheet_metadata": {
+    "additionalProperties": false,
+    "properties": {
+      "columns": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "columnIndex": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "columnLetter": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "columnName": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "columnSkipped": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                },
+                "columnType": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "format": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "gridProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "columnCount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "frozenColumnCount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "frozenRowCount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "rowCount": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      },
+      "index": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sheetId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sheetType": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "sheetUrl": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "spreadsheetId": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "title": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "sheets_loaded": {
+    "additionalProperties": false,
+    "properties": {
+      "lastRowNumber": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "loadDate": {
+        "format": "date-time",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "sheetId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "spreadsheetId": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "title": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "spreadsheet_metadata": {
+    "additionalProperties": false,
+    "properties": {
+      "properties": {
+        "additionalProperties": false,
+        "properties": {
+          "autoRecalc": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "locale": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "timeZone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      },
+      "spreadsheetId": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "spreadsheetUrl": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "type": "object"
+  }
+}

--- a/tests/regression/baseline/state_keys.json
+++ b/tests/regression/baseline/state_keys.json
@@ -1,0 +1,4 @@
+{
+  "empdetails": [],
+  "salary": []
+}

--- a/tests/regression/capture.py
+++ b/tests/regression/capture.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Baseline capture for tap-google-sheets — run once on Python 3.9.
+
+Required env vars:
+    TAP_GOOGLE_SHEETS_CLIENT_ID
+    TAP_GOOGLE_SHEETS_CLIENT_SECRET
+    TAP_GOOGLE_SHEETS_REFRESH_TOKEN
+    TAP_GOOGLE_SHEETS_SPREADSHEET_ID
+    TAP_GOOGLE_SHEETS_START_DATE  (optional, default 2010-01-01T00:00:00Z)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+BASELINE_DIR = Path(__file__).parent / "baseline"
+TAP_CMD = str(Path(sys.executable).parent / "tap-google-sheets")
+
+REQUIRED = [
+    "TAP_GOOGLE_SHEETS_CLIENT_ID",
+    "TAP_GOOGLE_SHEETS_CLIENT_SECRET",
+    "TAP_GOOGLE_SHEETS_REFRESH_TOKEN",
+    "TAP_GOOGLE_SHEETS_SPREADSHEET_ID",
+]
+
+
+def check_env():
+    missing = [v for v in REQUIRED if not os.getenv(v)]
+    if missing:
+        print(f"ERROR: Missing env vars: {missing}")
+        sys.exit(1)
+
+
+def write_config():
+    config = {
+        "client_id": os.environ["TAP_GOOGLE_SHEETS_CLIENT_ID"],
+        "client_secret": os.environ["TAP_GOOGLE_SHEETS_CLIENT_SECRET"],
+        "refresh_token": os.environ["TAP_GOOGLE_SHEETS_REFRESH_TOKEN"],
+        "spreadsheet_id": os.environ["TAP_GOOGLE_SHEETS_SPREADSHEET_ID"],
+        "start_date": os.getenv("TAP_GOOGLE_SHEETS_START_DATE", "2010-01-01T00:00:00Z"),
+        "user_agent": "peliqan-regression-capture/1.0",
+        "request_timeout": 300,
+    }
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(config, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def _env():
+    env = os.environ.copy()
+    env.setdefault("AES_SECRET_KEY", "peliqan-test-key")
+    return env
+
+
+def discover(config_path):
+    print("Discovering catalog...")
+    result = subprocess.run(
+        [TAP_CMD, "--config", config_path, "--discover"],
+        capture_output=True, text=True, env=_env()
+    )
+    if result.returncode != 0:
+        print("ERROR: discover failed.")
+        print("STDERR:", result.stderr[-2000:])
+        sys.exit(1)
+    catalog = json.loads(result.stdout)
+    print(f"Discovered {len(catalog.get('streams', []))} streams.")
+    return catalog
+
+
+def select_all(catalog):
+    for stream in catalog.get("streams", []):
+        for entry in stream.get("metadata", []):
+            entry.setdefault("metadata", {})["selected"] = True
+    return catalog
+
+
+def write_catalog(catalog):
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(catalog, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def run_sync(config_path, catalog_path):
+    print(f"Syncing with Python {sys.version.split()[0]}...")
+    result = subprocess.run(
+        [TAP_CMD, "--config", config_path, "--catalog", catalog_path],
+        capture_output=True, text=True, env=_env()
+    )
+    if result.returncode != 0:
+        print("WARNING: tap exited non-zero. Capturing partial output.")
+        print("STDERR:", result.stderr[-2000:])
+    return result.stdout
+
+
+def parse_output(output):
+    schemas, records, states = {}, {}, []
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        t = msg.get("type")
+        if t == "SCHEMA":
+            schemas[msg["stream"]] = msg["schema"]
+            records.setdefault(msg["stream"], [])
+        elif t == "RECORD":
+            records.setdefault(msg["stream"], []).append(msg["record"])
+        elif t == "STATE":
+            states.append(msg["value"])
+    return schemas, records, states
+
+
+def extract_state_keys(states):
+    keys = {}
+    for state in states:
+        for stream, bookmark in state.get("bookmarks", {}).items():
+            keys[stream] = sorted(bookmark.keys()) if isinstance(bookmark, dict) else []
+    return keys
+
+
+def extract_record_fields(records):
+    fields = {}
+    for stream, stream_records in records.items():
+        all_fields = set()
+        for record in stream_records:
+            all_fields.update(record.keys())
+        fields[stream] = sorted(all_fields)
+    return fields
+
+
+def main():
+    check_env()
+    config_path = write_config()
+    catalog_path = None
+
+    try:
+        catalog = discover(config_path)
+        select_all(catalog)
+        catalog_path = write_catalog(catalog)
+
+        output = run_sync(config_path, catalog_path)
+        schemas, records, states = parse_output(output)
+
+        BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+
+        (BASELINE_DIR / "catalog.json").write_text(
+            json.dumps(catalog, indent=2, sort_keys=True)
+        )
+        (BASELINE_DIR / "schemas.json").write_text(
+            json.dumps(schemas, indent=2, sort_keys=True)
+        )
+        print(f"Saved schemas for {len(schemas)} streams: {list(schemas.keys())}")
+
+        state_keys = extract_state_keys(states)
+        (BASELINE_DIR / "state_keys.json").write_text(
+            json.dumps(state_keys, indent=2, sort_keys=True)
+        )
+        print(f"Saved state keys for {len(state_keys)} streams")
+
+        record_fields = extract_record_fields(records)
+        (BASELINE_DIR / "record_fields.json").write_text(
+            json.dumps(record_fields, indent=2, sort_keys=True)
+        )
+        total = sum(len(v) for v in records.values())
+        print(f"Saved record fields for {len(record_fields)} streams ({total} records total)")
+
+        python_version = sys.version.split()[0]
+        meta = {"python_version": python_version, "streams": list(schemas.keys())}
+        (BASELINE_DIR / "meta.json").write_text(json.dumps(meta, indent=2))
+
+        print(f"\nBaseline captured on Python {python_version}.")
+        print(f"Files written to: {BASELINE_DIR}")
+
+    finally:
+        os.unlink(config_path)
+        if catalog_path:
+            os.unlink(catalog_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,119 @@
+"""
+Shared fixtures and utilities for tap-google-sheets regression tests.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REGRESSION_DIR = Path(__file__).parent
+BASELINE_DIR = REGRESSION_DIR / "baseline"
+TAP_CMD = str(Path(sys.executable).parent / "tap-google-sheets")
+
+REQUIRED_ENV = [
+    "TAP_GOOGLE_SHEETS_CLIENT_ID",
+    "TAP_GOOGLE_SHEETS_CLIENT_SECRET",
+    "TAP_GOOGLE_SHEETS_REFRESH_TOKEN",
+    "TAP_GOOGLE_SHEETS_SPREADSHEET_ID",
+]
+
+
+def build_config():
+    missing = [v for v in REQUIRED_ENV if not os.getenv(v)]
+    if missing:
+        pytest.skip(f"Missing required env vars: {missing}")
+
+    return {
+        "client_id": os.environ["TAP_GOOGLE_SHEETS_CLIENT_ID"],
+        "client_secret": os.environ["TAP_GOOGLE_SHEETS_CLIENT_SECRET"],
+        "refresh_token": os.environ["TAP_GOOGLE_SHEETS_REFRESH_TOKEN"],
+        "spreadsheet_id": os.environ["TAP_GOOGLE_SHEETS_SPREADSHEET_ID"],
+        "start_date": os.getenv("TAP_GOOGLE_SHEETS_START_DATE", "2010-01-01T00:00:00Z"),
+        "user_agent": "peliqan-regression/1.0",
+        "request_timeout": 300,
+    }
+
+
+def _tap_env():
+    env = os.environ.copy()
+    env.setdefault("AES_SECRET_KEY", "peliqan-test-key")
+    return env
+
+
+def discover_catalog(config_path):
+    """Run tap-google-sheets in --discover mode and return the catalog dict."""
+    result = subprocess.run(
+        [TAP_CMD, "--config", config_path, "--discover"],
+        capture_output=True, text=True, env=_tap_env()
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"discover failed: {result.stderr[-2000:]}")
+    return json.loads(result.stdout)
+
+
+def select_all_streams(catalog):
+    """Mark every stream and every field as selected in the catalog metadata."""
+    for stream in catalog.get("streams", []):
+        for entry in stream.get("metadata", []):
+            entry.setdefault("metadata", {})["selected"] = True
+    return catalog
+
+
+def write_catalog(catalog):
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(catalog, tmp)
+    tmp.close()
+    return tmp.name
+
+
+@pytest.fixture(scope="session")
+def config_file():
+    config = build_config()
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(config, tmp)
+    tmp.close()
+    yield tmp.name
+    os.unlink(tmp.name)
+
+
+@pytest.fixture(scope="session")
+def catalog_file(config_file):
+    catalog = discover_catalog(config_file)
+    select_all_streams(catalog)
+    path = write_catalog(catalog)
+    yield path
+    os.unlink(path)
+
+
+def run_tap(config_path, catalog_path=None, extra_args=None):
+    cmd = [TAP_CMD, "--config", config_path]
+    if catalog_path:
+        cmd += ["--catalog", catalog_path]
+    cmd += (extra_args or [])
+    result = subprocess.run(cmd, capture_output=True, text=True, env=_tap_env())
+    return result.stdout, result.stderr, result.returncode
+
+
+def parse_messages(stdout):
+    schemas, records, states = {}, {}, []
+    for line in stdout.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        t = msg.get("type")
+        if t == "SCHEMA":
+            schemas[msg["stream"]] = msg["schema"]
+            records.setdefault(msg["stream"], [])
+        elif t == "RECORD":
+            records.setdefault(msg["stream"], []).append(msg["record"])
+        elif t == "STATE":
+            states.append(msg["value"])
+    return schemas, records, states

--- a/tests/regression/pytest.ini
+++ b/tests/regression/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = .

--- a/tests/regression/run_capture.sh
+++ b/tests/regression/run_capture.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run baseline capture inside a Python 3.9 container.
+# Usage: bash run_capture.sh
+
+set -euo pipefail
+
+TAP_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "==> Running baseline capture in python:3.9-slim"
+echo "    Tap dir: $TAP_DIR"
+
+docker run --rm \
+  -v "$TAP_DIR":/tap \
+  -w /tap \
+  -e TAP_GOOGLE_SHEETS_CLIENT_ID="${TAP_GOOGLE_SHEETS_CLIENT_ID:?}" \
+  -e TAP_GOOGLE_SHEETS_CLIENT_SECRET="${TAP_GOOGLE_SHEETS_CLIENT_SECRET:?}" \
+  -e TAP_GOOGLE_SHEETS_REFRESH_TOKEN="${TAP_GOOGLE_SHEETS_REFRESH_TOKEN:?}" \
+  -e TAP_GOOGLE_SHEETS_SPREADSHEET_ID="${TAP_GOOGLE_SHEETS_SPREADSHEET_ID:?}" \
+  -e TAP_GOOGLE_SHEETS_START_DATE="${TAP_GOOGLE_SHEETS_START_DATE:-2010-01-01T00:00:00Z}" \
+  -e AES_SECRET_KEY="peliqan-test-key" \
+  python:3.9-slim \
+  bash -c "
+    apt-get update -qq && apt-get install -y -qq git > /dev/null
+    python -m venv /venv
+    /venv/bin/pip install -e . -q
+    /venv/bin/python tests/regression/capture.py
+  "
+
+echo ""
+echo "==> Baseline written to tests/regression/baseline/"

--- a/tests/regression/run_tests.sh
+++ b/tests/regression/run_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run regression tests inside a Python 3.11 container.
+# Usage: bash run_tests.sh
+
+set -euo pipefail
+
+TAP_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "==> Running regression tests in python:3.11-slim"
+echo "    Tap dir: $TAP_DIR"
+
+docker run --rm \
+  -v "$TAP_DIR":/tap \
+  -w /tap \
+  -e TAP_GOOGLE_SHEETS_CLIENT_ID="${TAP_GOOGLE_SHEETS_CLIENT_ID:?}" \
+  -e TAP_GOOGLE_SHEETS_CLIENT_SECRET="${TAP_GOOGLE_SHEETS_CLIENT_SECRET:?}" \
+  -e TAP_GOOGLE_SHEETS_REFRESH_TOKEN="${TAP_GOOGLE_SHEETS_REFRESH_TOKEN:?}" \
+  -e TAP_GOOGLE_SHEETS_SPREADSHEET_ID="${TAP_GOOGLE_SHEETS_SPREADSHEET_ID:?}" \
+  -e TAP_GOOGLE_SHEETS_START_DATE="${TAP_GOOGLE_SHEETS_START_DATE:-2010-01-01T00:00:00Z}" \
+  -e AES_SECRET_KEY="peliqan-test-key" \
+  python:3.11-slim \
+  bash -c "
+    apt-get update -qq && apt-get install -y -qq git > /dev/null
+    python -m venv /venv
+    /venv/bin/pip install -e . pytest -q
+    cd tests/regression && /venv/bin/python -m pytest test_regression.py -v
+  "

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -1,0 +1,108 @@
+"""
+tap-google-sheets regression tests — run on Python 3.11 after migration.
+Compares live output against baseline/ captured on Python 3.9.
+"""
+import json
+import sys
+
+import pytest
+
+from conftest import BASELINE_DIR, parse_messages, run_tap
+
+
+def load_baseline(filename):
+    path = BASELINE_DIR / filename
+    if not path.exists():
+        pytest.skip(f"Baseline file not found: {path}. Run capture.py on Python 3.9 first.")
+    return json.loads(path.read_text())
+
+
+def extract_state_keys(states):
+    keys = {}
+    for state in states:
+        for stream, bookmark in state.get("bookmarks", {}).items():
+            keys[stream] = sorted(bookmark.keys()) if isinstance(bookmark, dict) else []
+    return keys
+
+
+def extract_record_fields(records):
+    fields = {}
+    for stream, stream_records in records.items():
+        all_fields = set()
+        for record in stream_records:
+            all_fields.update(record.keys())
+        fields[stream] = sorted(all_fields)
+    return fields
+
+
+@pytest.fixture(scope="session")
+def live_output(config_file, catalog_file):
+    stdout, stderr, returncode = run_tap(config_file, catalog_path=catalog_file)
+    return stdout, stderr, returncode
+
+
+@pytest.fixture(scope="session")
+def parsed(live_output):
+    stdout, _, _ = live_output
+    return parse_messages(stdout)
+
+
+def test_python_version():
+    major, minor = sys.version_info[:2]
+    assert (major, minor) >= (3, 11), (
+        f"Expected Python >=3.11, got {major}.{minor}."
+    )
+
+
+def test_tap_exits_clean(live_output):
+    _, stderr, returncode = live_output
+    assert returncode == 0, f"tap exited {returncode}.\nstderr:\n{stderr[-2000:]}"
+
+
+def test_schemas_unchanged(parsed):
+    baseline = load_baseline("schemas.json")
+    schemas, _, _ = parsed
+    missing = set(baseline.keys()) - set(schemas.keys())
+    assert not missing, f"Streams dropped after migration: {missing}"
+    for stream, expected_schema in baseline.items():
+        actual_schema = schemas.get(stream)
+        assert actual_schema == expected_schema, (
+            f"Schema changed for stream '{stream}' after migration."
+        )
+
+
+def test_state_keys_unchanged(parsed):
+    baseline = load_baseline("state_keys.json")
+    _, _, states = parsed
+    if not states:
+        pytest.skip("No STATE messages emitted.")
+    actual_keys = extract_state_keys(states)
+    for stream, expected_keys in baseline.items():
+        actual = actual_keys.get(stream, [])
+        assert actual == expected_keys, (
+            f"State keys changed for '{stream}'.\nExpected: {expected_keys}\nGot:      {actual}"
+        )
+
+
+def test_record_fields_unchanged(parsed):
+    baseline = load_baseline("record_fields.json")
+    _, records, _ = parsed
+    actual_fields = extract_record_fields(records)
+    for stream, expected_fields in baseline.items():
+        if stream not in actual_fields:
+            pytest.fail(f"Stream '{stream}' emitted records on 3.9 but none on 3.11.")
+        actual = set(actual_fields[stream])
+        expected = set(expected_fields)
+        dropped = expected - actual
+        assert not dropped, f"Fields dropped from '{stream}' after migration: {dropped}"
+
+
+def test_no_new_unexpected_fields(parsed):
+    baseline = load_baseline("record_fields.json")
+    _, records, _ = parsed
+    actual_fields = extract_record_fields(records)
+    for stream, actual in actual_fields.items():
+        expected = set(baseline.get(stream, []))
+        new_fields = set(actual) - expected
+        if new_fields:
+            print(f"\nINFO: New fields in '{stream}' on 3.11: {new_fields}")


### PR DESCRIPTION
## Summary
- `backoff==1.8.0` → `>=2.2.1` — adds Python 3.11 classifiers; 2.x API is drop-in compatible for standard decorator usage
- `requests==2.22.0` → `>=2.28.0` — provisional Python 3.11 support added in 2.28; no breaking changes for existing usage

## Test plan
- [x] Docker install verified on Python 3.11.15 — installs cleanly with no changes
- [x] Both deps are pure Python — no 3.11 binary wheel issues